### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 name: Build Artifacts
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/desu-life/MeowpadConfigurator/security/code-scanning/1](https://github.com/desu-life/MeowpadConfigurator/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block and restrict the `GITHUB_TOKEN` to the least privileges required. This workflow checks out code and uploads build artifacts; it does not push, create releases, or modify issues/PRs. Therefore, `contents: read` is sufficient, and it can be defined once at the top level so it applies to all jobs.

The single best fix here is to add a root-level `permissions` block right under `name:` (before `on:`) in `.github/workflows/build-artifacts.yml`:

```yaml
name: Build Artifacts
permissions:
  contents: read
on:
  ...
```

No other functionality needs to change; the jobs and steps remain identical. No additional methods, imports, or definitions are needed because permissions are a native part of GitHub Actions workflow syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
